### PR TITLE
Remove --socket=x11

### DIFF
--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -7,7 +7,6 @@
 	"rename-icon": "moonlight",
 	"finish-args": [
 		"--share=network",
-		"--socket=x11",
 		"--socket=fallback-x11",
 		"--socket=wayland",
 		"--share=ipc",


### PR DESCRIPTION
Hopefully --socket=fallback-x11 has been around long enough that we won't have problems on really old versions of Flatpak.

See flathub/flathub#1452