### PR TITLE
Use Flathub submodules for SDL2 and Libdecor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -19,46 +19,9 @@
 	],
 	"cleanup": [ "/include", "*.a", "/share/ffmpeg" ],
 	"modules": [
-		{
-			"name": "libdecor",
-			"buildsystem": "meson",
-			"build-options": {
-				"config-opts": [
-					"-Ddemo=false"
-				]
-			},
-			"sources": [
-				{
-					"type": "git",
-					"url": "https://gitlab.gnome.org/jadahl/libdecor.git",
-					"commit": "e87dcfdaf83f332fa83b43c804fcf93c151ff0f5"
-				}
-			]
-		},
-		{
-			"name": "SDL2",
-			"build-options": {
-				"config-opts": [
-					"--prefix=/app",
-					"--disable-arts",
-					"--disable-esd",
-					"--disable-nas",
-					"--disable-alsa",
-					"--disable-oss",
-					"--disable-sndio",
-					"--disable-libudev",
-					"--disable-rpath"
-				]
-			},
-			"sources": [
-				{
-					"type": "git",
-					"url": "https://github.com/libsdl-org/SDL.git",
-					"tag": "release-2.26.0",
-					"commit": "0bfeed061b10ea7dd37c88d9bae1824bad760f3a"
-				}
-			]
-		},
+		"shared-modules/libdecor/libdecor-0.1.1.json",
+		"shared-modules/SDL2/SDL2-2.26.1.json",
+
 		{
 			"name": "ffnvcodec",
 			"no-autogen": true,


### PR DESCRIPTION
Makes the build process quite a bit cleaner.

Also, does it make sense for Moonlight to still build ffmpeg manually? can it not use the ffmpeg extension(s) provided by Flathub?

CC (?) @cgutman 