### PR TITLE
Unset libva variables that might leak into the container

### DIFF
--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -15,7 +15,10 @@
 		"--talk-name=org.freedesktop.ScreenSaver",
 		"--env=IGNORE_RFI_LATENCY_BUG=1",
 		"--env=QT_QUICK_CONTROLS_STYLE=Material",
-		"--env=LIBVA_DRIVER_NAME="
+		"--env=LIBVA_DRIVER_NAME=",
+		"--unset-env=LIBVA_DRIVER_NAME",
+		"--env=LIBVA_DRIVERS_PATH=",
+		"--unset-env=LIBVA_DRIVERS_PATH"
 	],
 	"cleanup": [ "/include", "*.a", "/share/ffmpeg" ],
 	"modules": [


### PR DESCRIPTION
libva environment variables from the host should be unset in the container, since the Flatpak runtime may have different drivers available and use a different driver path than the host.

See https://github.com/moonlight-stream/moonlight-qt/issues/1064