### PR TITLE
Enable HIDAPI in SDL

### DIFF
--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -49,7 +49,6 @@
 					"--disable-alsa",
 					"--disable-oss",
 					"--disable-sndio",
-					"--disable-libudev",
 					"--disable-rpath"
 				]
 			},

--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -58,7 +58,7 @@
 					"type": "git",
 					"url": "https://github.com/libsdl-org/SDL.git",
 					"//": "branch: SDL2",
-					"commit": "64294e45607c557e125969721e4f55b0867379d3"
+					"commit": "25eca09c7e65a014d3575a95f58b1fdf1d3a5274"
 				}
 			]
 		},


### PR DESCRIPTION
This is required for extended controller features like motion events, touchpad events, LED control, etc. It also helps in environments with older kernels that lack support for these advanced features in hid-sony, hid-playstation, and other HID drivers.

This requires the host have appropriate udev rules to allow access to these devices by Flatpak apps, otherwise SDL falls back to using the normal OS input APIs.