### PR TITLE
Update to FFmpeg 6.1 and remove libdecor

### DIFF
--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -23,23 +23,6 @@
 	"cleanup": [ "/include", "*.a", "/share/ffmpeg" ],
 	"modules": [
 		{
-			"name": "libdecor",
-			"buildsystem": "meson",
-			"build-options": {
-				"config-opts": [
-					"-Ddemo=false"
-				]
-			},
-			"sources": [
-				{
-					"type": "git",
-					"url": "https://gitlab.freedesktop.org/libdecor/libdecor.git",
-					"tag": "0.2.0",
-					"commit": "ad320fc0e0ec2cd75a87fed454a9c7d6d1921464"
-				}
-			]
-		},
-		{
 			"name": "SDL2",
 			"build-options": {
 				"config-opts": [

--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -94,11 +94,14 @@
 					"--enable-hwaccel=h264_vdpau",
 					"--enable-hwaccel=hevc_vdpau",
 					"--enable-hwaccel=av1_vdpau",
+					"--enable-libdrm",
+					"--enable-hwaccel=h264_vulkan",
+					"--enable-hwaccel=hevc_vulkan",
+					"--enable-hwaccel=av1_vulkan",
 					"--enable-nvdec",
 					"--enable-hwaccel=h264_nvdec",
 					"--enable-hwaccel=hevc_nvdec",
 					"--enable-hwaccel=av1_nvdec",
-					"--enable-libdrm",
 					"--enable-decoder=h264_v4l2m2m",
 					"--enable-decoder=hevc_v4l2m2m",
 					"--enable-libdav1d",
@@ -112,8 +115,8 @@
 				{
 					"type": "git",
 					"url": "https://github.com/cgutman/FFmpeg.git",
-					"//": "branch: moonlight_6_0_0_v4l2",
-					"commit": "946f1fc2d7d6816cb79a97137fe7e94ed3e2ca5b"
+					"//": "branch: moonlight_6_1_0",
+					"commit": "c49f643b5a4db17b2316552f59f9f6dd4bdc7a41"
 				}
 			]
 		},


### PR DESCRIPTION
libdecor is included in the FreeDesktop SDK runtime base, so we don't have to build it ourselves anymore.