### PR TITLE
Set SDL_VIDEO_WAYLAND_EMULATE_MOUSE_WARP=0 to resolve pointer lock issue

### DIFF
--- a/0001-Don-t-set-relative-warp-mode-based-on-absolute-relat.patch
+++ b/0001-Don-t-set-relative-warp-mode-based-on-absolute-relat.patch
@@ -1,0 +1,36 @@
+From 1cd588f25c3d48d8ede77f1e5ef4486ef9cb4a9d Mon Sep 17 00:00:00 2001
+From: Cameron Gutman <aicommander@gmail.com>
+Date: Sat, 27 Apr 2024 17:13:02 -0500
+Subject: [PATCH] Don't set relative warp mode based on absolute/relative mouse
+ mode
+
+This breaks pointer capture on Wayland when we start in absolute mouse
+mode (since warp is not supported on Wayland). It's also confusing to
+users because it leads to different relative mouse acceleration curves
+based on whether you start a stream in relative mode or not.
+---
+ app/streaming/input/input.cpp | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/app/streaming/input/input.cpp b/app/streaming/input/input.cpp
+index fb11938b..95db06e0 100644
+--- a/app/streaming/input/input.cpp
++++ b/app/streaming/input/input.cpp
+@@ -42,14 +42,6 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
+     // Allow gamepad input when the app doesn't have focus if requested
+     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, prefs.backgroundGamepad ? "1" : "0");
+ 
+-    // If absolute mouse mode is enabled, use relative mode warp (which
+-    // is via normal motion events that are influenced by mouse acceleration).
+-    // Otherwise, we'll use raw input capture which is straight from the device
+-    // without modification by the OS.
+-    SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP,
+-                            prefs.absoluteMouseMode ? "1" : "0",
+-                            SDL_HINT_OVERRIDE);
+-
+ #if !SDL_VERSION_ATLEAST(2, 0, 15)
+     // For older versions of SDL (2.0.14 and earlier), use SDL_HINT_GRAB_KEYBOARD
+     SDL_SetHintWithPriority(SDL_HINT_GRAB_KEYBOARD,
+-- 
+2.44.0
+

--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -13,6 +13,7 @@
 		"--socket=pulseaudio",
 		"--device=all",
 		"--talk-name=org.freedesktop.ScreenSaver",
+		"--env=SDL_VIDEO_WAYLAND_EMULATE_MOUSE_WARP=0",
 		"--env=IGNORE_RFI_LATENCY_BUG=1",
 		"--env=QT_QUICK_CONTROLS_STYLE=Material",
 		"--env=LIBVA_DRIVER_NAME=",

--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -145,6 +145,10 @@
 					"disable-shallow-clone": true,
 					"tag": "v5.0.1",
 					"commit": "3cb169ea263c3cf9bb1461af291ab1461244b592"
+				},
+				{
+					"type": "patch",
+					"path": "0001-Don-t-set-relative-warp-mode-based-on-absolute-relat.patch"
 				}
 			]
 		}


### PR DESCRIPTION
SDL will try to lock the mouse cursor on Wayland if it's not visible in order to support applications that assume they can warp the cursor (which isn't possible on Wayland). We don't want this behavior because it interferes with seamless mouse mode when toggling between windowed and fullscreen modes by unexpectedly locking the mouse cursor.

This is implemented in Moonlight itself with https://github.com/moonlight-stream/moonlight-qt/commit/ebfe035a185c37446c1fb49bfc78931ccd95be0e but v5.0.1 doesn't have it.