### PR TITLE
Add missing FFmpeg library flags

### DIFF
--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -186,6 +186,8 @@
 					"--disable-shared",
 					"--disable-all",
 					"--enable-avcodec",
+					"--enable-avformat",
+					"--enable-swscale",
 					"--enable-decoder=h264",
 					"--enable-decoder=hevc",
 					"--enable-decoder=av1",


### PR DESCRIPTION
v6.1.0 links against these. It works without them (linking against the shared libraries in the runtime), but we end up with a mix of FFmpeg libraries statically linked and dynamically loaded which may not be binary compatible.