### PR TITLE
Fix startup crash under Steam Deck Game Mode (gamescope WSI abort)

### DIFF
--- a/com.moonlight_stream.Moonlight.json
+++ b/com.moonlight_stream.Moonlight.json
@@ -40,6 +40,10 @@
 					"type": "git",
 					"url": "https://github.com/haasn/libplacebo.git",
 					"commit": "d4624cbfb37fdef337a7da5794b66202671a89cd"
+				},
+				{
+					"type": "patch",
+					"path": "libplacebo-disable-internally-synchronized-queues.patch"
 				}
 			],
 			"cleanup": [

--- a/libplacebo-disable-internally-synchronized-queues.patch
+++ b/libplacebo-disable-internally-synchronized-queues.patch
@@ -1,0 +1,18 @@
+diff --git a/src/vulkan/context.c b/src/vulkan/context.c
+index bc9084a..642f7b1 100644
+--- a/src/vulkan/context.c
++++ b/src/vulkan/context.c
+@@ -265,7 +265,12 @@ static_assert(PL_ARRAY_SIZE(pl_vulkan_recommended_extensions) + 1 ==
+ #ifdef VK_KHR_internally_synchronized_queues
+ static const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR synchronized_queues = {
+     .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR,
+-    .internallySynchronizedQueues = true,
++    // Explicitly disabled: creating queues with non-zero VkDeviceQueueCreateFlags
++    // crashes gamescope's WSI layer (vkroots fetches queues with the legacy
++    // vkGetDeviceQueue, which returns NULL for flagged queues). External queue
++    // locking is retained, matching behavior prior to this extension's adoption.
++    // See moonlight-qt#1925 / moonlight-qt#1930.
++    .internallySynchronizedQueues = false,
+ };
+ #endif
+ 


### PR DESCRIPTION
Since the freedesktop 25.08 runtime updated to Mesa 26.1.4 (2026-07-08), Moonlight crashes with SIGABRT on launch under gamescope sessions (Steam Deck Game Mode, Steam Machine). Desktop Mode is unaffected. Upstream reports: moonlight-stream/moonlight-qt#1930, moonlight-stream/moonlight-qt#1925.

Root cause chain:

1. Mesa 26.1.x advertises `VK_KHR_internally_synchronized_queues`.
2. The pinned libplacebo (`d4624cb`) unconditionally enables the feature and creates all Vulkan queues with `VK_DEVICE_QUEUE_CREATE_INTERNALLY_SYNCHRONIZED_BIT_KHR` (upstream MR videolan/libplacebo!809).
3. gamescope's WSI layer (vkroots) retrieves queues with legacy `vkGetDeviceQueue`, which per spec returns `VK_NULL_HANDLE` for queues created with non-zero flags, and hits `assert(obj)` -> abort.

Crash from a Steam Deck (SteamOS 3.8.14, coredumpctl):

```
Signal: 6 (ABRT)
#4  libVkLayer_FROG_gamescope_wsi_x86_64.so + 0x67c5
#5  libvulkan.so.1.4.321 + 0x3703c
#8  /app/lib/libplacebo.so.365 + 0x95ce9
#9  /app/bin/moonlight + 0xaeda2   (Vulkan renderer init)
```

This patch disables the `internallySynchronizedQueues` feature bit in libplacebo's recommended feature chain (one line + comment). Queues are then created with `flags=0`, libplacebo retains its external queue locking, and FFmpeg observes the disabled feature through the `device_features` chain Moonlight forwards - i.e., exact pre-!809 behavior, which is what Moonlight v6.1.0 was written against. No functional or performance cost for Moonlight's usage; HDR and gamescope WSI stay fully enabled.

The real fixes belong upstream (vkroots should use `vkGetDeviceQueue2` - PR submitted: https://github.com/misyltoad/vkroots/pull/17; libplacebo could gate the feature) - this is a downstream mitigation so Flathub users get a working Game Mode build now rather than after the next SteamOS/moonlight release cycle. The patch should be dropped when either upstream fix ships.

Tested on Steam Deck (SteamOS 3.8.14, Game Mode, 2026-07-15): the current Flathub build reproduces the SIGABRT on every Game Mode launch (fresh coredump, identical WSI-layer stack). With only this patch applied to libplacebo (built at the pinned commit with identical meson options and injected into the unmodified Flathub app), Moonlight launches and runs normally in Game Mode with the gamescope WSI layer active (HDR path intact).
